### PR TITLE
Modify to work with Datascript 0.18 and persistent-sorted-set.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,10 @@
   :dependencies
   [ [org.clojure/clojure        "1.8.0"  :scope "provided"]
     [org.clojure/clojurescript  "1.9.89" :scope "provided"]
-    [datascript                 "0.15.2" :scope "provided"]
-    [com.cognitect/transit-clj  "0.8.288"]
-    [com.cognitect/transit-cljs "0.8.239"] ]
+    [datascript                 "0.18.1" :scope "provided"]
+    [persistent-sorted-set      "0.1.0"  :scope "provided"]
+    [com.cognitect/transit-clj  "0.8.313"]
+    [com.cognitect/transit-cljs "0.8.256"] ]
   
   
   :global-vars

--- a/src/datascript/transit.clj
+++ b/src/datascript/transit.clj
@@ -5,7 +5,7 @@
     [cognitect.transit :as t])
   (:import
     [datascript.db DB Datom]
-    [datascript.btset BTSet]
+    [me.tonsky.persistent_sorted_set PersistentSortedSet]
     [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
 
@@ -21,10 +21,10 @@
                 :datoms (:eavt db) }))
     Datom (t/write-handler "datascript/Datom"
             (fn [^Datom d]
-              (if (.-added d)
-                [(.-e d) (.-a d) (.-v d) (.-tx d)]
-                [(.-e d) (.-a d) (.-v d) (.-tx d) false])))
-    BTSet (get t/default-write-handlers java.util.List) })
+              (if (db/datom-added d)
+                [(.-e d) (.-a d) (.-v d) (db/datom-tx d)]
+                [(.-e d) (.-a d) (.-v d) (db/datom-tx d) false])))
+    PersistentSortedSet (get t/default-write-handlers java.util.List) })
 
 
 (defn read-transit [is]

--- a/src/datascript/transit.cljs
+++ b/src/datascript/transit.cljs
@@ -2,7 +2,7 @@
   (:require
     [datascript.core :as d]
     [datascript.db   :as db]
-    [datascript.btset :as bt]
+    [me.tonsky.persistent-sorted-set :as pss]
     [cognitect.transit :as t]))
 
 
@@ -20,10 +20,10 @@
                    :datoms (:eavt db) }))
     db/Datom (t/write-handler (constantly "datascript/Datom")
                (fn [d]
-                 (if (.-added d)
-                   [(.-e d) (.-a d) (.-v d) (.-tx d)]
-                   [(.-e d) (.-a d) (.-v d) (.-tx d) false])))
-    bt/BTSet (t/ListHandler.) })
+                 (if (db/datom-added d)
+                   [(.-e d) (.-a d) (.-v d) (db/datom-tx d)]
+                   [(.-e d) (.-a d) (.-v d) (db/datom-tx d) false])))
+    pss/BTSet (t/ListHandler.) })
 
 
 (defn read-transit-str [s]


### PR DESCRIPTION
As of version 0.18 of Datascript, BTSet was extracted and moved to a separate project - [persistent-sorted-set](https://github.com/tonsky/persistent-sorted-set).
Add this new dependency and change code to work with this new data type.